### PR TITLE
Bugfix/implicit tiling recalculate bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [1.2.3] - 08-04-2024
+
+### Fixed
+
+- fixed calculation of bounds for items that do not have a boundingVolume available
+- added public RecalculateBounds method to recalculate all tilebounds in tileset
+- removed private legacy method 
+
 ## [1.2.1] - 16-02-2024
 
 ### Fixed

--- a/Runtime/Scripts/Read3DTileset.cs
+++ b/Runtime/Scripts/Read3DTileset.cs
@@ -16,7 +16,6 @@ namespace Netherlands3D.Tiles3D
     [RequireComponent(typeof(ReadSubtree))]
     public class Read3DTileset : MonoBehaviour
     {
-
         public string tilesetUrl = "https://storage.googleapis.com/ahp-research/maquette/kadaster/3dbasisvoorziening/test/landuse_1_1/tileset.json";
         public string publicKey;
         public string personalKey;
@@ -71,9 +70,9 @@ namespace Netherlands3D.Tiles3D
             }
 
 #else
-if (string.IsNullOrEmpty(publicKey)==false)
+            if (string.IsNullOrEmpty(publicKey)==false)
             {
-            tilesetUrl = tilesetUrl + "?key=" + publicKey;
+                tilesetUrl = tilesetUrl + "?key=" + publicKey;
             }
 #endif
         }
@@ -94,8 +93,6 @@ if (string.IsNullOrEmpty(publicKey)==false)
             ExtractDatasetPaths();
 
             StartCoroutine(LoadTileset());
-            
-
         }
 
         private void ExtractDatasetPaths()
@@ -187,15 +184,13 @@ if (string.IsNullOrEmpty(publicKey)==false)
             usingPrioritiser = (tilePrioritiser);
         }
 
-        private void RelativeCenterChanged(Vector3 cameraOffset)
+        public void RecalculateBounds()
         {
             if (root == null) return;
 
             //Flag all calculated bounds to be recalculated when tile bounds is requested
             RecalculateAllTileBounds(root);
         }
-
-
 
         /// <summary>
         /// Recursive recalculation of tile bounds
@@ -230,18 +225,12 @@ if (string.IsNullOrEmpty(publicKey)==false)
                 string jsonstring = www.downloadHandler.text;
                 ParseTileset.subtreeReader = GetComponent<ReadSubtree>();
                 JSONNode rootnode = JSON.Parse(jsonstring)["root"];
-               root = ParseTileset.ReadTileset(rootnode);
-                
+                root = ParseTileset.ReadTileset(rootnode);
             }
         }
 
         private void RequestContentUpdate(Tile tile)
         {
-            //tile.parent.IncrementLoadingChildren();
-            //foreach (var child in tile.children)
-            //{
-            //    child.IncrementLoadingParents();
-            //}
             if (!tile.content)
             {
                 var newContentGameObject = new GameObject($"{tile.level},{tile.X},{tile.Y} content");
@@ -294,24 +283,15 @@ if (string.IsNullOrEmpty(publicKey)==false)
             {
                 //If camera changed, recalculate what tiles are be in view
                 currentCamera.transform.GetPositionAndRotation(out currentCameraPosition, out currentCameraRotation);
+                lastCameraAngle = (currentCamera.orthographic ? currentCamera.orthographicSize : currentCamera.fieldOfView);
+                currentCamera.transform.GetPositionAndRotation(out lastCameraPosition, out lastCameraRotation);
 
-                //if (nestedTreeLoaded || CameraChanged())
-                //{
-                //    nestedTreeLoaded = false;
-
-                    lastCameraAngle = (currentCamera.orthographic ? currentCamera.orthographicSize : currentCamera.fieldOfView);
-                    currentCamera.transform.GetPositionAndRotation(out lastCameraPosition, out lastCameraRotation);
-
-                    SetSSEComponent(currentCamera);
-                    DisposeTilesOutsideView(currentCamera);
-
-                    //root.IsInViewFrustrum(currentCamera);
+                SetSSEComponent(currentCamera);
+                DisposeTilesOutsideView(currentCamera);
                 foreach (var child in root.children)
                 {
                     LoadInViewRecursively(child, currentCamera);
                 }
-                    
-                //}
 
                 yield return null;
             }
@@ -514,12 +494,7 @@ if (string.IsNullOrEmpty(publicKey)==false)
         {
             var relativeContentUrl = tile.contentUri;
 
-            //if (tilingMethod == TilingMethod.implicitTiling)
-            //{
-            //    relativeContentUrl = (implicitTilingSettings.contentUri.Replace("{level}", tile.X.ToString()).Replace("{x}", tile.Y.ToString()).Replace("{y}", tile.Z.ToString()));
-            //}
-
-            //RDam specific temp fix.
+            //RD amsterdam specific temp fix.
             relativeContentUrl = relativeContentUrl.Replace("../", "");
 
             var fullPath = (tile.contentUri.StartsWith("/")) ? rootPath + relativeContentUrl : absolutePath + relativeContentUrl;

--- a/Runtime/Scripts/Tileset/Content.cs
+++ b/Runtime/Scripts/Tileset/Content.cs
@@ -180,7 +180,6 @@ namespace Netherlands3D.Tiles3D
         {
             foreach (var renderer in parent.GetComponentsInChildren<Renderer>())
             {
-                Debug.Log(renderer.gameObject.name, renderer.gameObject);
                 renderer.material = overrideMaterial;
             }
         }

--- a/Runtime/Scripts/Tileset/ReadSubtree.cs
+++ b/Runtime/Scripts/Tileset/ReadSubtree.cs
@@ -93,12 +93,10 @@ namespace Netherlands3D.Tiles3D
             int localIndex = parentNortonIndex * 4;
             int levelstart = LevelStartIndex + (int)Mathf.Pow(4, (tile.level-appendTilesTo.level));
             
-
             AddChild(tile, localIndex, levelstart, 0);
             AddChild(tile, localIndex, levelstart, 1);
             AddChild(tile, localIndex, levelstart, 2);
             AddChild(tile, localIndex, levelstart, 3);
-
         }
 
         private void AddChild(Tile parentTile, int localIndex, int LevelStartIndex, int childNumber)

--- a/Runtime/Scripts/Tileset/ReadSubtree.cs
+++ b/Runtime/Scripts/Tileset/ReadSubtree.cs
@@ -103,7 +103,6 @@ namespace Netherlands3D.Tiles3D
 
         private void AddChild(Tile parentTile, int localIndex, int LevelStartIndex, int childNumber)
         {
-
             Tile childTile = new Tile();
             childTile.parent = parentTile;
             childTile.transform = parentTile.transform;
@@ -117,9 +116,6 @@ namespace Netherlands3D.Tiles3D
             childTile.geometricError = parentTile.geometricError / 2f;
             childTile.boundingVolume = parentTile.boundingVolume.GetChildBoundingVolume(childNumber,settings.subdivisionScheme);
            
-
-
-
             // check geometric content
             if (childTile.level < appendTilesTo.level + currentSubtreeLevels)
             {

--- a/Runtime/Scripts/Tileset/Tile.cs
+++ b/Runtime/Scripts/Tileset/Tile.cs
@@ -41,7 +41,7 @@ namespace Netherlands3D.Tiles3D
         public string contentUri = "";
 
         public Content content; //Gltf content
-        
+
         public int CountLoadingChildren()
         {
             int result = 0;
@@ -230,6 +230,9 @@ namespace Netherlands3D.Tiles3D
 
         public void CalculateBounds()
         {
+            if(boundingVolume == null || boundingVolume.values.Length == 0)
+                return;
+
             switch (boundingVolume.boundingVolumeType)
             {
                 case BoundingVolumeType.Box:

--- a/Runtime/Scripts/Tileset/Tile.cs
+++ b/Runtime/Scripts/Tileset/Tile.cs
@@ -14,6 +14,16 @@ namespace Netherlands3D.Tiles3D
         public int Y;
         public bool hascontent;
 
+        public int priority = 0;
+
+        private bool boundsAvailable = false;
+        private Bounds bounds = new Bounds();
+        public BoundingVolume boundingVolume;
+
+        public bool requestedDispose = false;
+        public bool requestedUpdate = false;
+        internal bool nestedTilesLoaded = false;
+
         public int childrenCountDelayingDispose = 0;
         public Tile parent;
 
@@ -24,7 +34,6 @@ namespace Netherlands3D.Tiles3D
         public float screenSpaceError = float.MaxValue;
 
         public string refine;
-        public BoundingVolume boundingVolume;
 
         public bool inView = false;
         public bool canRefine = false;
@@ -32,11 +41,7 @@ namespace Netherlands3D.Tiles3D
         public string contentUri = "";
 
         public Content content; //Gltf content
-
-
-
-
-
+        
         public int CountLoadingChildren()
         {
             int result = 0;
@@ -137,14 +142,6 @@ namespace Netherlands3D.Tiles3D
             }
             return result;
         }
-        public int priority = 0;
-
-        private bool boundsAvailable = false;
-        private Bounds bounds = new Bounds();
-
-        public bool requestedDispose = false;
-        public bool requestedUpdate = false;
-        internal bool nestedTilesLoaded = false;
 
         public Bounds ContentBounds
         {
@@ -209,13 +206,6 @@ namespace Netherlands3D.Tiles3D
             loaded
         }
 
-       
-       
-
-        
-
-      
-
         public bool IsInViewFrustrum(Camera ofCamera)
         {
             if (!boundsAvailable)
@@ -235,8 +225,6 @@ namespace Netherlands3D.Tiles3D
                 inView = ofCamera.InView(ContentBounds);
             }
             
-            
-
             return inView;
         }
 
@@ -262,11 +250,6 @@ namespace Netherlands3D.Tiles3D
                     bounds.Encapsulate(CoordinateConverter.ConvertTo(boxCenterEcef - Xaxis + Yaxis - Zaxis, CoordinateSystem.Unity).ToVector3());
                     bounds.Encapsulate(CoordinateConverter.ConvertTo(boxCenterEcef - Xaxis - Yaxis + Zaxis, CoordinateSystem.Unity).ToVector3());
                     bounds.Encapsulate(CoordinateConverter.ConvertTo(boxCenterEcef - Xaxis - Yaxis - Zaxis, CoordinateSystem.Unity).ToVector3());
-
-                    //bounds.Encapsulate(zAxisExt);
-                    //bounds.Encapsulate(xAxisExtInv);
-                    //bounds.Encapsulate(yAxisExtInv);
-                    //bounds.Encapsulate(zAxisExtInv);
 
                     break;
                 case BoundingVolumeType.Sphere:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eu.netherlands3d.tiles3d",
   "displayName": "Netherlands 3D - 3DTiles",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "unity": "2022.2",
   "type": "library",
   "keywords": [


### PR DESCRIPTION
- fixed calculation of bounds for items that do not have a boundingVolume available
- added public RecalculateBounds method to recalculate all tilebounds in tileset
- removed private legacy method 