### PR TITLE
Bugfix/layer assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.2.4] - 23-04-2024
+
+### Fixed
+
+- Removed forced assignment to layer 11 of the tile objects. Tile objects will take the parent object's layer by default, and will allow for manual assignment thereafter.
+
 ## [1.2.3] - 08-04-2024
 
 ### Fixed

--- a/Runtime/Scripts/Read3DTileset.cs
+++ b/Runtime/Scripts/Read3DTileset.cs
@@ -235,7 +235,7 @@ namespace Netherlands3D.Tiles3D
             {
                 var newContentGameObject = new GameObject($"{tile.level},{tile.X},{tile.Y} content");
                 newContentGameObject.transform.SetParent(transform, false);
-                newContentGameObject.layer = 11;
+                newContentGameObject.layer = gameObject.layer;
                 tile.content = newContentGameObject.AddComponent<Content>();
                 tile.content.State = Content.ContentLoadState.NOTLOADING;
                 tile.content.ParentTile = tile;
@@ -357,24 +357,6 @@ namespace Netherlands3D.Tiles3D
                         
                     }
                 }
-
-                int childcount = tile.CountLoadedChildren();
-                int layerIndex = 12;
-                if (childcount==0)
-                {
-                    layerIndex = 11;
-                }
-                if (tile.content != null)
-                {
-                    if (tile.content.gameObject != null)
-                    {
-                        foreach (var item in tile.content.gameObject.GetComponentsInChildren<Transform>())
-                        {
-                            item.gameObject.layer = layerIndex;
-                        }
-                    }
-                }
-
             }
         }
 

--- a/Runtime/Scripts/Tileset/Content.cs
+++ b/Runtime/Scripts/Tileset/Content.cs
@@ -153,11 +153,6 @@ namespace Netherlands3D.Tiles3D
 
                 this.gameObject.name = uri;
                 
-                foreach (var item in this.gameObject.GetComponentsInChildren<Transform>())
-                {
-                    item.gameObject.layer = 11;
-                }
-
                 //Check if mesh features addon is used to define subobjects
 
 #if SUBOBJECT

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eu.netherlands3d.tiles3d",
   "displayName": "Netherlands 3D - 3DTiles",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "unity": "2022.2",
   "type": "library",
   "keywords": [


### PR DESCRIPTION
Removed forced assignment to layer 11 of the tile objects. Tile objects will take the parent object's layer by default, and will allow for manual assignment thereafter.