### PR TITLE
Invalidate Bounds on re-enable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.5.2] - 07-06-2024
+
+### Fixed
+- tile-locations were incorrect after re-enabeling tileLayer
+
 ## [1.5.1] - 07-06-2024
 
 ### Fixed

--- a/Runtime/Scripts/Read3DTileset.cs
+++ b/Runtime/Scripts/Read3DTileset.cs
@@ -117,6 +117,7 @@ namespace Netherlands3D.Tiles3D
         {
             if (root !=null)
             {
+                InvalidateBounds();
                 StartCoroutine(LoadInView());
             }
             

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eu.netherlands3d.tiles3d",
   "displayName": "Netherlands 3D - 3DTiles",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "unity": "2022.2",
   "type": "library",
   "keywords": [


### PR DESCRIPTION
call invalidateBounds when re-enable, because the origin might have been shifted