### PR TITLE
I have replaced the Gltfast by us with the one from Unity. With this …

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "eu.netherlands3d.coordinates": "1.3.0",
-    "eu.netherlands3d.gltfast": "5.0.3",
+    "com.unity.cloud.gltfast": "6.7.0",
     "com.unity.meshopt.decompress": "0.1.0-preview.5"
   },
   "description": "enables the use of 3DTilesets",


### PR DESCRIPTION
…commit, we get performance issues due to an explosion of shaders that we had more or less solved in our own version (by custom stripping).

This commit should not be merged to main until that is resolved