### PR TITLE
Bugfix/remove credentials from url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.9.0] - 12-12-2024
+
+### Added
+- Added function to clear the key query from the url, this will allow keys to be removed if this is desired, and it will prevent multiple valid keys from being added to the url as was the case before
+
 ## [1.8.0] - 11-12-2024
 
 ### Added

--- a/Runtime/Scripts/Read3DTileset.cs
+++ b/Runtime/Scripts/Read3DTileset.cs
@@ -87,9 +87,19 @@ namespace Netherlands3D.Tiles3D
         [HideInInspector] public UnityEvent<UnityWebRequest.Result> OnServerRequestFailed = new();
         [HideInInspector] public UnityEvent<ContentMetadata> OnLoadAssetMetadata = new();
 
-
+        public string CredentialQuery { get; private set; } = string.Empty;
+        
+        public void ClearKeyFromURL()
+        {
+            if (CredentialQuery != string.Empty)
+            {
+                tilesetUrl = tilesetUrl.Replace(CredentialQuery, string.Empty);
+            }
+        }
+        
         public void ConstructURLWithKey()
         {
+            ClearKeyFromURL(); //remove existing key if any is there
             UriBuilder uriBuilder = new UriBuilder(tilesetUrl);
 
             //Keep an existing query
@@ -105,15 +115,13 @@ namespace Netherlands3D.Tiles3D
             //Append the key query parameter
 #if UNITY_EDITOR
             if (!string.IsNullOrEmpty(personalKey))
-            {
-                uriBuilder.Query += $"{QueryKeyName}={personalKey}";
-            }
 #else
             if (!string.IsNullOrEmpty(publicKey))
-            {
-                uriBuilder.Query += $"{QueryKeyName}={publicKey}";
-            }
 #endif
+            {
+                CredentialQuery = $"{QueryKeyName}={personalKey}";
+                uriBuilder.Query += CredentialQuery;
+            }
             tilesetUrl = uriBuilder.ToString();
         }
 

--- a/Runtime/Scripts/Read3DTileset.cs
+++ b/Runtime/Scripts/Read3DTileset.cs
@@ -115,13 +115,17 @@ namespace Netherlands3D.Tiles3D
             //Append the key query parameter
 #if UNITY_EDITOR
             if (!string.IsNullOrEmpty(personalKey))
-#else
-            if (!string.IsNullOrEmpty(publicKey))
-#endif
             {
                 CredentialQuery = $"{QueryKeyName}={personalKey}";
                 uriBuilder.Query += CredentialQuery;
             }
+#else
+            if (!string.IsNullOrEmpty(publicKey))
+            {
+                CredentialQuery = $"{QueryKeyName}={publicKey}";
+                uriBuilder.Query += CredentialQuery;
+            }
+#endif
             tilesetUrl = uriBuilder.ToString();
         }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eu.netherlands3d.tiles3d",
   "displayName": "Netherlands 3D - 3DTiles",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "unity": "2022.2",
   "type": "library",
   "keywords": [


### PR DESCRIPTION
Added function to clear the key query from the url, this will allow keys to be removed if this is desired, and it will prevent multiple valid keys from being added to the url as was the case before.