### PR TITLE
fix url-querys for tilecontent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.10.1] - 10-1-2025
+
+### Fixed
+- QueryParameters for tileContent no longer overwritten when trying to add authentication-parameters 
+
 ## [1.10.0] - 13-12-2024
 
 ### Added

--- a/Runtime/Scripts/Read3DTileset.cs
+++ b/Runtime/Scripts/Read3DTileset.cs
@@ -659,15 +659,15 @@ namespace Netherlands3D.Tiles3D
             //Combine query to pass on session id and API key (Google Maps 3DTiles API style)
             UriBuilder uriBuilder = new(fullPath);
             NameValueCollection contentQueryParameters = ParseQueryString(uriBuilder.Query);
-            foreach (string key in contentQueryParameters.Keys)
+            foreach (string key in queryParameters.Keys)
             {
-                if (!queryParameters.AllKeys.Contains(key))
+                if (!contentQueryParameters.AllKeys.Contains(key))
                 {
-                    queryParameters.Add(key, contentQueryParameters[key]);
+                    contentQueryParameters.Add(key, queryParameters[key]);
                 }
             }
 
-            uriBuilder.Query = ToQueryString(queryParameters);
+            uriBuilder.Query = ToQueryString(contentQueryParameters);
             var url = uriBuilder.ToString();
             return url;
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eu.netherlands3d.tiles3d",
   "displayName": "Netherlands 3D - 3DTiles",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "unity": "2022.2",
   "type": "library",
   "keywords": [


### PR DESCRIPTION
add global query-parameters to contentquery-parameters if not yet set in contentQueryParameters (like authorization-tokens) if not already set in contentQueryParameters.