### PR TITLE
Fix realitymesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+## [1.10.3] - 23-1-2025
+
+### Fixed
+- Fixed BoundingVolume-transformation
 
 ## [1.10.2] - 14-1-2025
 

--- a/Runtime/Scripts/Tileset/BoundingVolume.cs
+++ b/Runtime/Scripts/Tileset/BoundingVolume.cs
@@ -14,24 +14,24 @@ namespace Netherlands3D.Tiles3D{
                 case BoundingVolumeType.Box:
                     Coordinate center = new Coordinate(CoordinateSystem.Undefined, values[0], values[1], values[2]);
                     Coordinate newCenter = tiletransform.MultiplyPoint3x4(center);
-                    values[0] = newCenter.Points[0];
-                    values[1] = newCenter.Points[1];
-                    values[2] = newCenter.Points[2];
+                    values[0] = newCenter.value1;
+                    values[1] = newCenter.value2;
+                    values[2] = newCenter.value3;
                     Coordinate xAxis = new Coordinate(CoordinateSystem.Undefined, values[3], values[4], values[5]);
                     Coordinate newXAxis = tiletransform.MultiplyVector(xAxis);
-                    values[3] = newXAxis.Points[0];
-                    values[4] = newXAxis.Points[1];
-                    values[5] = newXAxis.Points[2];
+                    values[3] = newXAxis.value1;
+                    values[4] = newXAxis.value2;
+                    values[5] = newXAxis.value3;
                     Coordinate yAxis = new Coordinate(CoordinateSystem.Undefined, values[6], values[7], values[8]);
                     Coordinate newYAxis = tiletransform.MultiplyVector(yAxis);
-                    values[6] = newYAxis.Points[0];
-                    values[7] = newYAxis.Points[1];
-                    values[8] = newYAxis.Points[2];
+                    values[6] = newYAxis.value1;
+                    values[7] = newYAxis.value2;
+                    values[8] = newYAxis.value3;
                     Coordinate zAxis = new Coordinate(CoordinateSystem.Undefined, values[9], values[10], values[11]);
                     Coordinate newZAxis = tiletransform.MultiplyVector(zAxis);
-                    values[9] = newZAxis.Points[0];
-                    values[10] = newZAxis.Points[1];
-                    values[11] = newZAxis.Points[2];
+                    values[9] = newZAxis.value1;
+                    values[10] = newZAxis.value2;
+                    values[11] = newZAxis.value3;
                     break;
                 case BoundingVolumeType.Sphere:
                     break;

--- a/Runtime/Scripts/Tileset/ParseTileset.cs
+++ b/Runtime/Scripts/Tileset/ParseTileset.cs
@@ -101,6 +101,10 @@ namespace Netherlands3D.Tiles3D
             {
                 tile.tileTransform = tile.parent.tileTransform * myTileTransform;
             }
+            else
+            {
+                tile.tileTransform = myTileTransform;
+            }
            
             tile.boundingVolume = new BoundingVolume();
             JSONNode boundingVolumeNode = node["boundingVolume"];

--- a/Runtime/Scripts/Tileset/Tile.cs
+++ b/Runtime/Scripts/Tileset/Tile.cs
@@ -319,9 +319,9 @@ namespace Netherlands3D.Tiles3D
                     unityBounds.Encapsulate((boxCenterEcef - Xaxis - Yaxis - Zaxis).ToUnity());
 
 
-                    double deltaX =  Math.Abs(Xaxis.Points[0]) + Math.Abs(Yaxis.Points[0]) + Math.Abs(Zaxis.Points[0]);
-                    double deltaY = Math.Abs(Xaxis.Points[1]) + Math.Abs(Yaxis.Points[1]) + Math.Abs(Zaxis.Points[1]);
-                    double deltaZ = Math.Abs(Xaxis.Points[2]) + Math.Abs(Yaxis.Points[2]) + Math.Abs(Zaxis.Points[2]);
+                    double deltaX =  Math.Abs(Xaxis.value1) + Math.Abs(Yaxis.value1) + Math.Abs(Zaxis.value1);
+                    double deltaY = Math.Abs(Xaxis.value2) + Math.Abs(Yaxis.value2) + Math.Abs(Zaxis.value2);
+                    double deltaZ = Math.Abs(Xaxis.value3) + Math.Abs(Yaxis.value3) + Math.Abs(Zaxis.value3);
                     BottomLeft = new Coordinate(CoordinateSystem.WGS84_ECEF , boxCenterEcef.Points[0]-deltaX, boxCenterEcef.Points[1] - deltaY, boxCenterEcef.Points[2] - deltaZ);
                     TopRight = new Coordinate(CoordinateSystem.WGS84_ECEF, boxCenterEcef.Points[0] + deltaX, boxCenterEcef.Points[1] + deltaY, boxCenterEcef.Points[2] + deltaZ);
 

--- a/Runtime/Scripts/Tileset/TileTransform.cs
+++ b/Runtime/Scripts/Tileset/TileTransform.cs
@@ -135,17 +135,17 @@ namespace Netherlands3D.Tiles3D
         public Coordinate MultiplyPoint3x4(Coordinate point)
         {
             Coordinate res = new Coordinate(point.CoordinateSystem,0,0,0);
-            res.value1 = this.m00 * point.Points[0] + this.m01 * point.Points[1] + this.m02 * point.height + this.m03;
-            res.value2= this.m10 * point.Points[0] + this.m11 * point.Points[1] + this.m12 * point.height + this.m13;
-            res.value3 = this.m20 * point.Points[0] + this.m21 * point.Points[1] + this.m22 * point.height + this.m23;
+            res.value1 = this.m00 * point.value1 + this.m01 * point.value2 + this.m02 * point.value3 + this.m03;
+            res.value2= this.m10 * point.value1 + this.m11 * point.value2+ this.m12 * point.value3 + this.m13;
+            res.value3 = this.m20 * point.value1 + this.m21 * point.value2+ this.m22 * point.value3 + this.m23;
             return res;
         }
         public Coordinate MultiplyVector(Coordinate point)
         {
             Coordinate res = new Coordinate(point.CoordinateSystem, 0, 0, 0);
-            res.value1 = this.m00 * point.Points[0] + this.m01 * point.Points[1] + this.m02*point.Points[2] ;
-            res.value2 = this.m10 * point.Points[0] + this.m11 * point.Points[1] + this.m12 * point.Points[2];
-            res.value3 = this.m20 * point.Points[0] + this.m21 * point.Points[1] + this.m22 * point.Points[2];
+            res.value1 = this.m00 * point.value1 + this.m01 * point.value2 + this.m02*point.value3 ;
+            res.value2 = this.m10 * point.value1 + this.m11 * point.value2 + this.m12 * point.value3;
+            res.value3 = this.m20 * point.value1 + this.m21 * point.value2 + this.m22 * point.value3;
             return res;
         }
     }

--- a/Runtime/Scripts/Tileset/TileTransform.cs
+++ b/Runtime/Scripts/Tileset/TileTransform.cs
@@ -134,18 +134,18 @@ namespace Netherlands3D.Tiles3D
         // Transforms a position by this matrix, without a perspective divide. (fast)
         public Coordinate MultiplyPoint3x4(Coordinate point)
         {
-            Coordinate res = new Coordinate(point.CoordinateSystem,new double[3]);
-            res.Points[0] = this.m00 * point.Points[0] + this.m01 * point.Points[1] + this.m02 * point.height + this.m03;
-            res.Points[1]= this.m10 * point.Points[0] + this.m11 * point.Points[1] + this.m12 * point.height + this.m13;
-            res.Points[2] = this.m20 * point.Points[0] + this.m21 * point.Points[1] + this.m22 * point.height + this.m23;
+            Coordinate res = new Coordinate(point.CoordinateSystem,0,0,0);
+            res.value1 = this.m00 * point.Points[0] + this.m01 * point.Points[1] + this.m02 * point.height + this.m03;
+            res.value2= this.m10 * point.Points[0] + this.m11 * point.Points[1] + this.m12 * point.height + this.m13;
+            res.value3 = this.m20 * point.Points[0] + this.m21 * point.Points[1] + this.m22 * point.height + this.m23;
             return res;
         }
         public Coordinate MultiplyVector(Coordinate point)
         {
-            Coordinate res = new Coordinate(point.CoordinateSystem, new double[3]);
-            res.Points[0] = this.m00 * point.Points[0] + this.m01 * point.Points[1] + this.m02*point.Points[2] ;
-            res.Points[1] = this.m10 * point.Points[0] + this.m11 * point.Points[1] + this.m12 * point.Points[2];
-            res.Points[2] = this.m20 * point.Points[0] + this.m21 * point.Points[1] + this.m22 * point.Points[2];
+            Coordinate res = new Coordinate(point.CoordinateSystem, 0, 0, 0);
+            res.value1 = this.m00 * point.Points[0] + this.m01 * point.Points[1] + this.m02*point.Points[2] ;
+            res.value2 = this.m10 * point.Points[0] + this.m11 * point.Points[1] + this.m12 * point.Points[2];
+            res.value3 = this.m20 * point.Points[0] + this.m21 * point.Points[1] + this.m22 * point.Points[2];
             return res;
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eu.netherlands3d.tiles3d",
   "displayName": "Netherlands 3D - 3DTiles",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "unity": "2022.2",
   "type": "library",
   "keywords": [


### PR DESCRIPTION
in 3dtilesets with boundingVolume.Box
code was using the old coordinate.Points[i]= to set values for a coordinate, resulting in a coordinate with all values  set to zero.